### PR TITLE
Added default news module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ NODE_ENV=development
 NPM_TOKEN=
 
 WEATHER_API_KEY=
+
+NEWS_API_KEY=

--- a/src/modules/news/index.js
+++ b/src/modules/news/index.js
@@ -1,0 +1,45 @@
+import { action, actions } from '@smith-ai/smith-actions';
+import News from './news';
+
+const news = new News(process.env.NEWS_API_KEY);
+
+const getHeadlines = (articles) => articles
+    .map((article) => ` - ${article.title}`)
+    .join('.\n');
+
+const getTopHeadlines = (articles) => {
+    const headlines = getHeadlines(articles);
+
+    return `Here are the top headlines from ${articles[0].source.name}:\n${headlines}`;
+};
+
+action('give me the top headlines for', async (keyword) => {
+    const articles = await news.headlines({ keyword });
+
+    const headlines = getHeadlines(articles);
+
+    return `Here are the top headlines for ${keyword}:\n${headlines}`;
+});
+
+action('give me the top headlines from', async (source) => {
+    const sourceId = source
+        .toLowerCase()
+        .split(' ')
+        .join('-');
+
+    const articles = await news.headlines({
+        source: sourceId,
+    });
+
+    return getTopHeadlines(articles);
+});
+
+action('give me the top headlines', async () => {
+    const articles = await news.headlines({ 
+        source: 'bbc-news',
+    });
+
+    return getTopHeadlines(articles);
+});
+
+export { actions };

--- a/src/modules/news/news.js
+++ b/src/modules/news/news.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+
+export default class News {
+    /**
+     * Constructor. Create a new News API client
+     * using the given API key.
+     * 
+     * @param {string} apiKey News API key
+     */
+    constructor(apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Helper function for executing a News API request.
+     * 
+     * @param {string} endpoint API endpoint to hit
+     * @param {object} params GET parameters to use in the request
+     */
+    async doRequest(endpoint, params) {
+        params.apiKey = this.apiKey;
+
+        const result = await axios({
+            url: `https://newsapi.org/v2/${endpoint}`,
+            method: 'get',
+            params,
+        });
+
+        return result.data;
+    }
+
+    /**
+     * Get the top headlines for the given conditions.
+     * 
+     * @param {object} param0 Parameters to retrieve headlines for
+     * @param {number} pageSize Number of articles to include in a page
+     * @param {number} page Page to retrieve
+     */
+    async headlines({ keyword = null, country = null, category = null, source = null }, pageSize = 5, page = 1) {
+        const params = { pageSize, page };
+
+        if (keyword) params.q = keyword;
+
+        if (source) {
+            params.sources = source;
+        } else {
+            if (country) params.country = country;
+            if (category) params.category = category;
+        }
+
+        const result = await this.doRequest('top-headlines', params);
+
+        return result.articles;
+    }
+}


### PR DESCRIPTION
This feature adds a default news module that uses the [News API](https://newsapi.org/) to retrieve the top headlines from a wide range of different sources. It adds the following new commands:

- `give me the top headlines`
- `give me the top headlines from [source]`
- `give me the top headlines for [keyword]`