### PR TITLE
Added module OAuth support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ USER node
 COPY --chown=node:node .npmrc ./
 COPY --chown=node:node package*.json ./
 
+RUN envsubst < .npmrc > ~/.npmrc
+RUN envsubst < .npmrc > .npmrc
+
+RUN npm cache clean --force
 RUN npm install
 
 COPY --chown=node:node . .
-
-RUN envsubst < .npmrc > ~/.npmrc
 
 EXPOSE 3500
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - "../smith-modules/:/home/node/smith-modules"
     ports:
       - 3500:3500
-    environment:
-      - NODE_ENV=${NODE_ENV}
+    env_file:
+      - .env
   mongo:
     image: andresvidal/rpi3-mongodb3:latest
     container_name: "mongo"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,6 +1417,23 @@
          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
       },
+      "body-parser": {
+         "version": "1.19.0",
+         "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+         "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+         "requires": {
+            "bytes": "3.1.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "1.7.2",
+            "iconv-lite": "0.4.24",
+            "on-finished": "~2.3.0",
+            "qs": "6.7.0",
+            "raw-body": "2.4.0",
+            "type-is": "~1.6.17"
+         }
+      },
       "boxen": {
          "version": "1.3.0",
          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",

--- a/src/controllers/moduleController.js
+++ b/src/controllers/moduleController.js
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import moduleService from '../services/moduleService';
+
+/**
+ * Entrypoint for completing authentication for
+ * a module.
+ *
+ * @param {Request} req Express request object
+ * @param {Response} res Express response object
+ */
+const auth = async (req, res) => {
+    const { module } = req.params;
+    
+    await moduleService.authModule(module, req);
+
+    return res.json(`Successfully authenticated module: ${module}`);
+};
+
+export {
+    auth,
+};

--- a/src/models/modules.js
+++ b/src/models/modules.js
@@ -43,6 +43,19 @@ const get = async (name) => {
 };
 
 /**
+ * Update an existing module in the MongoDB collection
+ * by name.
+ *
+ * @param {string} name Name of module to update
+ * @param {object} config Config data to update
+ */
+const update = async (name, config = {}) => {
+    const coll = await modules();
+
+    return coll.updateOne({ name }, { $set: { config } });
+};
+
+/**
  * Remove a module from the MongoDB collection by name.
  * 
  * @param {string} name Name of module to remove
@@ -57,5 +70,6 @@ export default {
     add,
     all,
     get,
+    update,
     remove,
 };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,5 +1,6 @@
 import * as express from 'express';
-import { invoke, invokeSocket } from '../controllers/invokeController';
+import * as invokeController from '../controllers/invokeController';
+import * as moduleController from '../controllers/moduleController';
 
 /**
  * Retrieve API routes
@@ -7,9 +8,11 @@ import { invoke, invokeSocket } from '../controllers/invokeController';
 const getRoutes = async () => {
     const router = express.Router();
 
-    router.post('/invoke', invoke);
+    router.post('/invoke', invokeController.invoke);
+    router.ws('/invoke', invokeController.invokeSocket);
 
-    router.ws('/invoke', invokeSocket);
+    router.get('/:module/auth', moduleController.auth);
+    router.post('/:module/auth', moduleController.auth);
 
     return router;
 }

--- a/src/services/moduleService.js
+++ b/src/services/moduleService.js
@@ -17,6 +17,24 @@ const getDefaultModulePath = () => resolve('dist/modules')
 const getModuleInstallName = (module) => `@smith-ai/smith-${module}`;
 
 /**
+ * Complete authentication with the given module.
+ * Expects a request object containing auth details
+ * relevant to the module.
+ *
+ * @param {string} module Name of module to auth with
+ * @param {Request} req Express request object
+ */
+const authModule = async (module, req) => {
+    const { auth } = requireModule(module);
+
+    const config = await auth(req);
+
+    await modules.update(module, config);
+
+    return true;
+};
+
+/**
  * Require the given module
  * 
  * @param {string} module Name of module to require
@@ -159,6 +177,7 @@ const loadModules = (modules, isDefault = false) => {
 }
 
 export default {
+    authModule,
     installModule,
     uninstallModule,
     load,


### PR DESCRIPTION
This feature adds support for carrying out authentication within a module, this is intended for use with OAuth services when authenticating with third-party platforms such as Google, Apple etc which commonly involve a callback being sent to complete user authentication.

This comes in the form of GET and POST endpoints for `/api/:module/auth`, which will route the request through to the specified module to be handled by an `auth` function declared in the module. A module authentication function should carry out any necessary steps to complete authentication with the given request, and return an updated config object for the module containing any updated keys, tokens etc.